### PR TITLE
feat(core): define evidence bundle types and JSON Schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ Thumbs.db
 # Test & coverage
 coverage/
 
+# Worktrees
+.worktrees/
+
 # Internal docs (not published)
 internal-doc/
 docs/plans/

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
     "schemas"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "pnpm clean && tsc",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "tsc --noEmit",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,10 +9,12 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
-    }
+    },
+    "./schemas/evidence-bundle.schema.json": "./schemas/evidence-bundle.schema.json"
   },
   "files": [
-    "dist"
+    "dist",
+    "schemas"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/core/schemas/evidence-bundle.schema.json
+++ b/packages/core/schemas/evidence-bundle.schema.json
@@ -1,0 +1,158 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://usermind.dev/schemas/evidence-bundle.schema.json",
+  "title": "EvidenceBundle",
+  "description": "Complete execution trace for a single Usermind flow run.",
+  "type": "object",
+  "required": [
+    "flowName",
+    "sessionId",
+    "actor",
+    "startedAt",
+    "finishedAt",
+    "status",
+    "steps",
+    "errors"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "flowName": {
+      "type": "string",
+      "description": "Name of the flow that was executed."
+    },
+    "sessionId": {
+      "type": "string",
+      "description": "Unique identifier for this execution session."
+    },
+    "actor": { "$ref": "#/$defs/Actor" },
+    "startedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 timestamp of when execution started."
+    },
+    "finishedAt": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "ISO-8601 timestamp of when execution finished, or null while still running."
+    },
+    "status": { "$ref": "#/$defs/BundleStatus" },
+    "steps": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/EvidenceStepResult" },
+      "description": "Ordered list of step-level evidence."
+    },
+    "errors": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/EvidenceError" },
+      "description": "Errors encountered during execution."
+    }
+  },
+  "$defs": {
+    "Actor": {
+      "type": "object",
+      "description": "Role-aware identity that the agent assumes during flow execution.",
+      "required": ["role"],
+      "additionalProperties": false,
+      "properties": {
+        "role": {
+          "type": "string",
+          "description": "The role the agent assumes (e.g. \"admin\", \"user\", \"visitor\")."
+        },
+        "permissions": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Permissions associated with this role."
+        },
+        "session": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "Key-value session data interpolated at runtime."
+        }
+      }
+    },
+    "BundleStatus": {
+      "type": "string",
+      "enum": ["passed", "failed", "error", "running"],
+      "description": "Overall outcome of a flow execution."
+    },
+    "ActionType": {
+      "type": "string",
+      "enum": ["navigate", "click", "fill", "assert", "select", "hover", "wait"],
+      "description": "Union of all built-in action type identifiers."
+    },
+    "StepResultStatus": {
+      "type": "string",
+      "enum": ["passed", "failed", "error", "skipped"],
+      "description": "Outcome of an individual step execution."
+    },
+    "EvidenceStepResult": {
+      "type": "object",
+      "description": "Evidence record for a single step within a flow run.",
+      "required": [
+        "stepIndex",
+        "action",
+        "target",
+        "result",
+        "timestamp",
+        "screenshot"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "stepIndex": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Zero-based position of this step in the flow's steps array."
+        },
+        "action": { "$ref": "#/$defs/ActionType" },
+        "target": {
+          "type": "string",
+          "description": "Target of the action: URL, selector, or duration-as-string."
+        },
+        "result": { "$ref": "#/$defs/StepResultStatus" },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO-8601 timestamp of when the step completed."
+        },
+        "screenshot": {
+          "type": ["string", "null"],
+          "description": "Screenshot path, data URI, or null if not captured."
+        },
+        "durationMs": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Wall-clock duration in milliseconds."
+        }
+      }
+    },
+    "EvidenceError": {
+      "type": "object",
+      "description": "A single error captured during flow execution.",
+      "required": ["code", "message", "stepIndex", "timestamp"],
+      "additionalProperties": false,
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Error classification code (e.g. \"TimeoutError\")."
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable error message."
+        },
+        "stepIndex": {
+          "type": ["integer", "null"],
+          "description": "Zero-based index of the step that caused the error, or null for flow-level errors."
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO-8601 timestamp of when the error occurred."
+        },
+        "details": {
+          "type": "string",
+          "description": "Optional additional context (stack trace, DOM snapshot, etc.)."
+        }
+      }
+    }
+  }
+}

--- a/packages/core/src/__tests__/evidence.test.ts
+++ b/packages/core/src/__tests__/evidence.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, expectTypeOf } from "vitest";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import type {
+  EvidenceBundle,
+  BundleStatus,
+  EvidenceStepResult,
+  StepResultStatus,
+  EvidenceError,
+} from "../index.js";
+
+describe("Evidence type definitions", () => {
+  it("exports all evidence types from the package root", () => {
+    expectTypeOf<EvidenceBundle>().toBeObject();
+    expectTypeOf<EvidenceStepResult>().toBeObject();
+    expectTypeOf<EvidenceError>().toBeObject();
+    expectTypeOf<BundleStatus>().toBeString();
+    expectTypeOf<StepResultStatus>().toBeString();
+  });
+
+  it("represents a complete evidence bundle", () => {
+    const bundle: EvidenceBundle = {
+      flowName: "login-flow",
+      sessionId: "sess-abc-123",
+      actor: { role: "admin", permissions: ["read", "write"] },
+      startedAt: "2025-01-15T10:00:00.000Z",
+      finishedAt: "2025-01-15T10:00:05.000Z",
+      status: "passed",
+      steps: [
+        {
+          stepIndex: 0,
+          action: "navigate",
+          target: "https://example.com/login",
+          result: "passed",
+          timestamp: "2025-01-15T10:00:01.000Z",
+          screenshot: "screenshots/step-0.png",
+          durationMs: 1200,
+        },
+        {
+          stepIndex: 1,
+          action: "fill",
+          target: "#email",
+          result: "passed",
+          timestamp: "2025-01-15T10:00:02.000Z",
+          screenshot: null,
+        },
+      ],
+      errors: [],
+    };
+
+    expect(bundle.flowName).toBe("login-flow");
+    expect(bundle.actor.role).toBe("admin");
+    expect(bundle.steps).toHaveLength(2);
+    expect(bundle.steps[0].screenshot).toBe("screenshots/step-0.png");
+    expect(bundle.steps[1].screenshot).toBeNull();
+  });
+
+  it("represents a running bundle with null finishedAt", () => {
+    const bundle: EvidenceBundle = {
+      flowName: "checkout-flow",
+      sessionId: "sess-def-456",
+      actor: { role: "user" },
+      startedAt: "2025-01-15T10:00:00.000Z",
+      finishedAt: null,
+      status: "running",
+      steps: [],
+      errors: [],
+    };
+
+    expect(bundle.finishedAt).toBeNull();
+    expect(bundle.status).toBe("running");
+  });
+
+  it("represents a failed bundle with errors", () => {
+    const bundle: EvidenceBundle = {
+      flowName: "search-flow",
+      sessionId: "sess-ghi-789",
+      actor: { role: "visitor" },
+      startedAt: "2025-01-15T10:00:00.000Z",
+      finishedAt: "2025-01-15T10:00:03.000Z",
+      status: "failed",
+      steps: [
+        {
+          stepIndex: 0,
+          action: "navigate",
+          target: "https://example.com",
+          result: "passed",
+          timestamp: "2025-01-15T10:00:01.000Z",
+          screenshot: null,
+        },
+        {
+          stepIndex: 1,
+          action: "assert",
+          target: "h1",
+          result: "failed",
+          timestamp: "2025-01-15T10:00:02.000Z",
+          screenshot: "screenshots/step-1.png",
+          durationMs: 50,
+        },
+      ],
+      errors: [
+        {
+          code: "AssertionError",
+          message: 'Expected "Welcome" but found "Error"',
+          stepIndex: 1,
+          timestamp: "2025-01-15T10:00:02.000Z",
+        },
+      ],
+    };
+
+    expect(bundle.status).toBe("failed");
+    expect(bundle.errors).toHaveLength(1);
+    expect(bundle.errors[0].stepIndex).toBe(1);
+  });
+
+  it("represents a flow-level error with null stepIndex", () => {
+    const error: EvidenceError = {
+      code: "SessionError",
+      message: "Browser crashed unexpectedly",
+      stepIndex: null,
+      timestamp: "2025-01-15T10:00:00.000Z",
+      details: "Chrome process exited with code 139",
+    };
+
+    expect(error.stepIndex).toBeNull();
+    expect(error.details).toBeDefined();
+  });
+
+  it("covers all BundleStatus values", () => {
+    const statuses: BundleStatus[] = ["passed", "failed", "error", "running"];
+    expect(statuses).toHaveLength(4);
+  });
+
+  it("covers all StepResultStatus values", () => {
+    const statuses: StepResultStatus[] = [
+      "passed",
+      "failed",
+      "error",
+      "skipped",
+    ];
+    expect(statuses).toHaveLength(4);
+  });
+});
+
+describe("Evidence bundle JSON Schema", () => {
+  let schema: Record<string, unknown>;
+
+  it("is valid JSON", async () => {
+    const schemaPath = resolve(
+      import.meta.dirname,
+      "../../schemas/evidence-bundle.schema.json",
+    );
+    const raw = await readFile(schemaPath, "utf-8");
+    schema = JSON.parse(raw);
+    expect(schema).toBeDefined();
+  });
+
+  it("uses draft 2020-12", async () => {
+    const schemaPath = resolve(
+      import.meta.dirname,
+      "../../schemas/evidence-bundle.schema.json",
+    );
+    schema = JSON.parse(await readFile(schemaPath, "utf-8"));
+    expect(schema.$schema).toBe(
+      "https://json-schema.org/draft/2020-12/schema",
+    );
+  });
+
+  it("requires all top-level bundle fields", async () => {
+    const schemaPath = resolve(
+      import.meta.dirname,
+      "../../schemas/evidence-bundle.schema.json",
+    );
+    schema = JSON.parse(await readFile(schemaPath, "utf-8"));
+    const required = schema.required as string[];
+    expect(required).toContain("flowName");
+    expect(required).toContain("sessionId");
+    expect(required).toContain("actor");
+    expect(required).toContain("startedAt");
+    expect(required).toContain("finishedAt");
+    expect(required).toContain("status");
+    expect(required).toContain("steps");
+    expect(required).toContain("errors");
+  });
+
+  it("disallows additional properties on all objects", async () => {
+    const schemaPath = resolve(
+      import.meta.dirname,
+      "../../schemas/evidence-bundle.schema.json",
+    );
+    schema = JSON.parse(await readFile(schemaPath, "utf-8"));
+
+    expect(schema.additionalProperties).toBe(false);
+
+    const defs = schema.$defs as Record<string, Record<string, unknown>>;
+    for (const [name, def] of Object.entries(defs)) {
+      if (def.type === "object") {
+        expect(
+          def.additionalProperties,
+          `$defs.${name} should disallow additional properties`,
+        ).toBe(false);
+      }
+    }
+  });
+
+  it("defines all expected $defs", async () => {
+    const schemaPath = resolve(
+      import.meta.dirname,
+      "../../schemas/evidence-bundle.schema.json",
+    );
+    schema = JSON.parse(await readFile(schemaPath, "utf-8"));
+    const defs = schema.$defs as Record<string, unknown>;
+    expect(Object.keys(defs).sort()).toEqual([
+      "ActionType",
+      "Actor",
+      "BundleStatus",
+      "EvidenceError",
+      "EvidenceStepResult",
+      "StepResultStatus",
+    ]);
+  });
+
+  it("defines BundleStatus enum values matching TypeScript type", async () => {
+    const schemaPath = resolve(
+      import.meta.dirname,
+      "../../schemas/evidence-bundle.schema.json",
+    );
+    schema = JSON.parse(await readFile(schemaPath, "utf-8"));
+    const defs = schema.$defs as Record<
+      string,
+      Record<string, unknown>
+    >;
+    const bundleStatus = defs.BundleStatus;
+    expect(bundleStatus.enum).toEqual(["passed", "failed", "error", "running"]);
+  });
+
+  it("defines StepResultStatus enum values matching TypeScript type", async () => {
+    const schemaPath = resolve(
+      import.meta.dirname,
+      "../../schemas/evidence-bundle.schema.json",
+    );
+    schema = JSON.parse(await readFile(schemaPath, "utf-8"));
+    const defs = schema.$defs as Record<
+      string,
+      Record<string, unknown>
+    >;
+    const stepStatus = defs.StepResultStatus;
+    expect(stepStatus.enum).toEqual(["passed", "failed", "error", "skipped"]);
+  });
+
+  it("defines ActionType enum matching DSL action types", async () => {
+    const schemaPath = resolve(
+      import.meta.dirname,
+      "../../schemas/evidence-bundle.schema.json",
+    );
+    schema = JSON.parse(await readFile(schemaPath, "utf-8"));
+    const defs = schema.$defs as Record<
+      string,
+      Record<string, unknown>
+    >;
+    const actionType = defs.ActionType;
+    expect(actionType.enum).toEqual([
+      "navigate",
+      "click",
+      "fill",
+      "assert",
+      "select",
+      "hover",
+      "wait",
+    ]);
+  });
+});

--- a/packages/core/src/evidence/index.ts
+++ b/packages/core/src/evidence/index.ts
@@ -1,0 +1,3 @@
+export type { EvidenceError } from "./types/error-entry.js";
+export type { EvidenceStepResult, StepResultStatus } from "./types/step-result.js";
+export type { EvidenceBundle, BundleStatus } from "./types/bundle.js";

--- a/packages/core/src/evidence/types/bundle.ts
+++ b/packages/core/src/evidence/types/bundle.ts
@@ -1,0 +1,32 @@
+import type { Actor } from "../../dsl/types/actor.js";
+import type { EvidenceStepResult } from "./step-result.js";
+import type { EvidenceError } from "./error-entry.js";
+
+/** Overall outcome of a flow execution. */
+export type BundleStatus = "passed" | "failed" | "error" | "running";
+
+/**
+ * Complete execution trace for a single flow run.
+ *
+ * Captures the identity (flow + actor), timing, step-by-step results,
+ * and any errors that occurred. This is the top-level evidence artifact
+ * produced by the runner and consumed by reporters / dashboards.
+ */
+export interface EvidenceBundle {
+  /** Name of the flow that was executed. */
+  flowName: string;
+  /** Unique identifier for this execution session. */
+  sessionId: string;
+  /** The actor (role + permissions + session data) that ran the flow. */
+  actor: Actor;
+  /** ISO-8601 timestamp of when execution started. */
+  startedAt: string;
+  /** ISO-8601 timestamp of when execution finished, or `null` while still running. */
+  finishedAt: string | null;
+  /** Aggregate status of the execution. */
+  status: BundleStatus;
+  /** Ordered list of step-level evidence, one entry per executed step. */
+  steps: EvidenceStepResult[];
+  /** Errors encountered during execution (step-level and flow-level). */
+  errors: EvidenceError[];
+}

--- a/packages/core/src/evidence/types/error-entry.ts
+++ b/packages/core/src/evidence/types/error-entry.ts
@@ -1,0 +1,18 @@
+/**
+ * A single error captured during flow execution.
+ *
+ * Errors can occur at the flow level (e.g. session setup failure)
+ * or at a specific step (assertion mismatch, timeout).
+ */
+export interface EvidenceError {
+  /** Error classification code (e.g. "TimeoutError", "AssertionError"). */
+  code: string;
+  /** Human-readable error message. */
+  message: string;
+  /** Zero-based index of the step that caused the error, or `null` for flow-level errors. */
+  stepIndex: number | null;
+  /** ISO-8601 timestamp of when the error occurred. */
+  timestamp: string;
+  /** Optional additional context (stack trace, DOM snapshot, etc.). */
+  details?: string;
+}

--- a/packages/core/src/evidence/types/step-result.ts
+++ b/packages/core/src/evidence/types/step-result.ts
@@ -1,0 +1,27 @@
+import type { ActionType } from "../../dsl/types/step.js";
+
+/** Outcome of an individual step execution. */
+export type StepResultStatus = "passed" | "failed" | "error" | "skipped";
+
+/**
+ * Evidence record for a single step within a flow run.
+ *
+ * - `failed` = the step's assertion did not match (functional failure)
+ * - `error`  = infrastructure problem (timeout, crash, network issue)
+ */
+export interface EvidenceStepResult {
+  /** Zero-based position of this step in the flow's `steps` array. */
+  stepIndex: number;
+  /** The action type that was executed. */
+  action: ActionType;
+  /** Target of the action: URL for navigate, selector for click/fill, duration-as-string for wait. */
+  target: string;
+  /** Outcome of the step execution. */
+  result: StepResultStatus;
+  /** ISO-8601 timestamp of when the step completed. */
+  timestamp: string;
+  /** Screenshot path, data URI, or `null` if not captured. */
+  screenshot: string | null;
+  /** Wall-clock duration in milliseconds (omitted if not measured). */
+  durationMs?: number;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,3 +20,11 @@ export type {
 } from "./dsl/index.js";
 
 export { parseFlow, ParseError, ACTION_TYPES, REQUIRED_FIELDS } from "./dsl/index.js";
+
+export type {
+  EvidenceBundle,
+  BundleStatus,
+  EvidenceStepResult,
+  StepResultStatus,
+  EvidenceError,
+} from "./evidence/index.js";

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
 }


### PR DESCRIPTION
## Summary

- Add TypeScript type definitions for evidence bundles: `EvidenceBundle`, `EvidenceStepResult`, `EvidenceError` with their status unions (`BundleStatus`, `StepResultStatus`)
- Create JSON Schema (draft 2020-12) at `schemas/evidence-bundle.schema.json` with `additionalProperties: false` on all objects for strict validation
- Reuse `Actor` and `ActionType` from the DSL types — no duplication
- Wire barrel exports from `evidence/index.ts` through `src/index.ts` and add a subpath export for the schema in `package.json`

Closes #22

## Test plan

- 15 new tests in `evidence.test.ts` covering type compilation, bundle construction (passed/running/failed states), flow-level vs step-level errors, and JSON Schema structure validation (draft version, required fields, `additionalProperties: false`, enum values matching TypeScript types)
- All 80 tests pass (`pnpm test`)
- Clean build produces `dist/evidence/` with declarations (`pnpm build`)
- `tsc --noEmit` lint passes (`pnpm lint`)

## Checklist

- [x] Tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm build`)
- [x] No breaking changes (or documented in summary)